### PR TITLE
Fix bug that creates duplicate folders with same name

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -473,6 +473,20 @@ class GoogleDriveAdapter extends AbstractAdapter
      */
     public function createDir($dirname, Config $config, $internalCall = false)
     {
+        try {
+            $meta = $this->getMetadata($dirname);
+        } catch (FileNotFoundException $e) {
+            $meta = false;
+        }
+
+        if ($meta !== false) {
+            return [
+                'path'      => $meta['path'],
+                'filename'  => $meta['filename'],
+                'extension' => $meta['extension']
+            ];
+        }
+
         list($pdir, $name) = $this->splitPath($dirname, false);
         if($this->useDisplayPaths) {
             if($pdir !== $this->root) {


### PR DESCRIPTION
If you call `createDir` multiple times with the same name it creates multiple same directories.