### PR TITLE
Set getFileObject as public

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -1055,7 +1055,7 @@ class GoogleDriveAdapter extends AbstractAdapter
      *
      * @return Google_Service_Drive_DriveFile|null
      */
-    protected function getFileObject($path, $checkDir = false)
+    public function getFileObject($path, $checkDir = false)
     {
         list(, $itemId) = $this->splitPath($path);
         if(isset($this->cacheFileObjects[$itemId])) {


### PR DESCRIPTION
There are a lot of cases that we need to get the original Google_Service_Drive_DriveFile object to work with advanced features.