### PR TITLE
[1.x] Uncache folders, get drive service, empty trash

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -1568,6 +1568,7 @@ class GoogleDriveAdapter extends AbstractAdapter
             $this->uncacheId($path);
         }
     }
+
     protected function uncacheId($id)
     {
         if (empty($id)) {

--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -1564,7 +1564,7 @@ class GoogleDriveAdapter extends AbstractAdapter
             } catch (FileNotFoundException $e) {
                 // unnecesary
             }
-        }else{
+        } else {
             $this->uncacheId($path);
         }
     }


### PR DESCRIPTION
* **`getService()`** added
Closes #27, useful in laravel's facade because `$service` creation is in a `ServiceProvider`,
example `Storage::disk('google')->getDriver()->getAdapter()->getService()`

* **`emptyTrash(array $params = [])`** added
Closes #28,  bridge to Google_Service_Drive's emptyTrash(for laravel), 
example `Storage::disk('google')->getDriver()->getAdapter()->emptyTrash()`
    >the issue is the storage become full before a month 

* **`uncacheFolder($path)`** added
Closes #29, useful on concurrent laravel's jobs, also it can be used like a workaround for avoid duplicity forcing to take first folder always(performance cost, but on queued jobs maybe doesn't matter, **can be added something like this for avoid duplicity always?**)
     >Unfortunately Google Drive allows users to create files and folders with same (displayed) names

     **Example for [#29](https://github.com/masbug/flysystem-google-drive-ext/issues/29) :**
```php
$disk=\Storage::disk('google');    
$disk->createDir('test/testa'); //create dir, gets id to cache if it's already exists
//manually delete o permanently destroy on drive without adapter, 
//also maybe another concurrent thread could create a directory with the same name first, now this is a duplicate
$dir=$disk->getDriver()->getAdapter()->getMetadata('test/testa');
$disk->getDriver()->getAdapter()->getService()->files->delete($dir['id']); 
//uncache
$disk->getDriver()->getAdapter()->uncacheFolder('test/testa'); 
//refresh folder id and put file(duplicates stays empty because get first on refresh, if directory was deleted, it creates a new one)
$disk->put('test/testa/file.txt', 'Contents1'); 
```
**still might lead to unexpected problems on concurrent delete, but can it helps to handle duplicates on createDir?**
