### PR TITLE
[1.x] usePermanentDelete config

### DIFF
--- a/tests/GoogleDriveAdapterTests.php
+++ b/tests/GoogleDriveAdapterTests.php
@@ -92,7 +92,7 @@ class GoogleDriveAdapterTests extends TestCase
             ) {
                 self::markTestSkipped("No google service config found in {$file}.");
             }
-            $options = [];
+            $options = ['usePermanentDelete' => true];
             if (!empty($config['teamDriveId'] ?? null)) {
                 $options['teamDriveId'] = $config['teamDriveId'];
             }


### PR DESCRIPTION
>@erikn69 I think it might be useful to add a config param that would toggle weather or not to add files to trash folder ($file->setTrashed(true)) or just plain delete them.

**usePermanentDelete** added on options
```
PHPUnit 9.5.7 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.0.5
Configuration: google_flysystem/phpunit.xml.dist

......................                                            22 / 22 (100%)

Time: 01:46.874, Memory: 8.00 MB

OK (22 tests, 99 assertions)
```
Now test uses `$options = ['usePermanentDelete' => true];`

Fixes #28 

Also update 2.x with merge, there are conflicts