### PR TITLE
Support for Psr7^2.0.0, small doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For example: virtual path `/Xa3X9GlR6EmbnY1RLVTk5VUtOVkk/0B3X9GlR6EmbnY1RLVTk5VU
 ## Installation
 
 ```bash
-composer require masbug/flysystem-google-drive-ext
+composer require masbug/flysystem-google-drive-ext:"^1.0.0"
 ```
 
 ## Getting Google Keys
@@ -80,12 +80,12 @@ $contents = $fs->listContents('MyFolder', true /* is_recursive */);
 $local_filepath = '/home/user/downloads/file_to_upload.ext';
 $remote_filepath = 'MyFolder/file.ext';
 
-$localAdapter = new League\Flysystem\Adapter\Local();
+$localAdapter = new League\Flysystem\Adapter\Local('/');
 $localfs = new \League\Flysystem\Filesystem($localAdapter, ['visibility' => AdapterInterface::VISIBILITY_PRIVATE]);
 
 try {
     $time = Carbon::now();
-    $ret = $fs->putStream($remote_filepath, $localfs->readStream($local_filepath));
+    $ret = $fs->writeStream($remote_filepath, $localfs->readStream($local_filepath), new \League\Flysystem\Config());
     if($ret) {
         $speed = filesize($local_filepath) / (float)$time->diffInSeconds();
         echo 'Elapsed time: '.$time->diffForHumans(null, true);
@@ -106,12 +106,12 @@ try {
 $remote_filepath = 'MyFolder/file.ext';
 $local_filepath = '/home/user/downloads/file.ext';
 
-$localAdapter = new League\Flysystem\Adapter\Local();
+$localAdapter = new League\Flysystem\Adapter\Local('/');
 $localfs = new \League\Flysystem\Filesystem($localAdapter, ['visibility' => AdapterInterface::VISIBILITY_PRIVATE]);
 
 try {
     $time = Carbon::now();
-    $ret = $localfs->putStream($local_filepath, $fs->readStream($remote_filepath));
+    $ret = $localfs->writeStream($local_filepath, $fs->readStream($remote_filepath), new \League\Flysystem\Config());
     if($ret) {
         $speed = filesize($local_filepath) / (float)$time->diffInSeconds();
         echo 'Elapsed time: '.$time->diffForHumans(null, true);
@@ -221,7 +221,7 @@ $googleDisk = Storage::disk('google');
 //$secondDisk = Storage::disk('second_google'); //others disks
 ```
 
-Keep in mind that there can only be one default cloud storage drive, defined by `FILESYSTEM_CLOUD` in your `.env` (or config) file. If you set it to `main_google`, that will be the cloud drive:
+Keep in mind that there can only be one default cloud storage drive, defined by `FILESYSTEM_CLOUD` in your `.env` (or config) file. If you set it to `google`, that will be the cloud drive:
 ```php
 Storage::cloud(); // refers to Storage::disk('google')
 ```
@@ -235,7 +235,7 @@ Concurrent use of same Google Drive might lead to unexpected problems due to hea
 ## Acknowledgements
 This adapter is based on wonderful [flysystem-google-drive](https://github.com/nao-pon/flysystem-google-drive) by Naoki Sawada.
 
-It also contains an adaptation of [Google_Http_MediaFileUpload](https://github.com/google/google-api-php-client/blob/master/src/Google/Http/MediaFileUpload.php) by Google. I've added support for resumable uploads directly from streams (avoiding copying data to memory). 
+It also contains an adaptation of [Google_Http_MediaFileUpload](https://github.com/googleapis/google-api-php-client/blob/master/src/Http/MediaFileUpload.php) by Google. I've added support for resumable uploads directly from streams (avoiding copying data to memory).
 
 TeamDrive support was implemented by Maximilian Ruta - [Deltachaos](https://github.com/Deltachaos).
 

--- a/src/StreamableUpload.php
+++ b/src/StreamableUpload.php
@@ -23,7 +23,7 @@ namespace Masbug\Flysystem;
 
 use Google_Client;
 use Google_Http_REST;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\LimitStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\RequestInterface;
@@ -72,18 +72,19 @@ class StreamableUpload
 
     /**
      * Result code from last HTTP call
+     *
      * @var int
      */
     private $httpResultCode;
 
     /**
-     * @param Google_Client                        $client
-     * @param RequestInterface                     $request
-     * @param string                               $mimeType
-     * @param null|string|resource|StreamInterface $data      Data you want to upload
-     * @param bool                                 $resumable
-     * @param bool|int                             $chunkSize File will be uploaded in chunks of this many bytes.
-     *                                                        Only used if resumable=True.
+     * @param  Google_Client  $client
+     * @param  RequestInterface  $request
+     * @param  string  $mimeType
+     * @param  null|string|resource|StreamInterface  $data  Data you want to upload
+     * @param  bool  $resumable
+     * @param  bool|int  $chunkSize  File will be uploaded in chunks of this many bytes.
+     *                               Only used if resumable=True.
      */
     public function __construct(
         Google_Client $client,
@@ -96,7 +97,15 @@ class StreamableUpload
         $this->client = $client;
         $this->request = $request;
         $this->mimeType = $mimeType;
-        $this->data = $data !== null ? Psr7\stream_for($data) : null;
+        if ($data !== null) {
+            if (function_exists('\GuzzleHttp\Psr7\stream_for')) {
+                $this->data = \GuzzleHttp\Psr7\stream_for($data);
+            } else {
+                $this->data = \GuzzleHttp\Psr7\Utils::streamFor($data);
+            }
+        } else {
+            $this->data = null;
+        }
         $this->resumable = $resumable;
         $this->chunkSize = is_bool($chunkSize) ? 0 : $chunkSize;
         $this->progress = 0;
@@ -113,7 +122,8 @@ class StreamableUpload
 
     /**
      * Set the size of the file that is being uploaded.
-     * @param int $size file size in bytes
+     *
+     * @param  int  $size  file size in bytes
      */
     public function setFileSize($size)
     {
@@ -122,6 +132,7 @@ class StreamableUpload
 
     /**
      * Return the progress on the upload
+     *
      * @return int progress in bytes uploaded.
      */
     public function getProgress()
@@ -131,8 +142,9 @@ class StreamableUpload
 
     /**
      * Send the next part of the file to upload.
-     * @param null|bool|string|StreamInterface $chunk The next set of bytes to send. If stream is provided then chunkSize is ignored.
-     *                                                If false it will use $this->data set at construct time.
+     *
+     * @param  null|bool|string|StreamInterface  $chunk  The next set of bytes to send. If stream is provided then chunkSize is ignored.
+     *                                                   If false it will use $this->data set at construct time.
      * @return false|mixed
      */
     public function nextChunk($chunk = false)
@@ -150,9 +162,13 @@ class StreamableUpload
             if ($this->data->eof()) {
                 return true; // finished
             }
-            $chunk = new Psr7\LimitStream($this->data, $this->chunkSize, $this->data->tell());
+            $chunk = new LimitStream($this->data, $this->chunkSize, $this->data->tell());
         } else {
-            $chunk = Psr7\stream_for($chunk);
+            if (function_exists('\GuzzleHttp\Psr7\stream_for')) {
+                $chunk = \GuzzleHttp\Psr7\stream_for($chunk);
+            } else {
+                $chunk = \GuzzleHttp\Psr7\Utils::streamFor($chunk);
+            }
         }
         $size = $chunk->getSize();
 
@@ -183,6 +199,7 @@ class StreamableUpload
 
     /**
      * Return the HTTP result code from the last call made.
+     *
      * @return int code
      */
     public function getHttpResultCode()
@@ -194,7 +211,7 @@ class StreamableUpload
      * Sends a PUT-Request to google drive and parses the response,
      * setting the appropriate variables from the response()
      *
-     * @param RequestInterface $request the request which will be sent
+     * @param  RequestInterface  $request  the request which will be sent
      * @return false|mixed false when the upload is unfinished or the decoded http response
      */
     private function makePutRequest(RequestInterface $request)
@@ -226,7 +243,8 @@ class StreamableUpload
 
     /**
      * Resume a previously unfinished upload
-     * @param string $resumeUri The resume-URI of the unfinished, resumable upload.
+     *
+     * @param  string  $resumeUri  The resume-URI of the unfinished, resumable upload.
      * @return false|mixed
      */
     public function resume($resumeUri)
@@ -292,8 +310,13 @@ class StreamableUpload
                 }
             }
         }
+        if (function_exists('\GuzzleHttp\Psr7\stream_for')) {
+            $stream = \GuzzleHttp\Psr7\stream_for($postBody);
+        } else {
+            $stream = \GuzzleHttp\Psr7\Utils::streamFor($postBody);
+        }
 
-        $request = $request->withBody(Psr7\stream_for($postBody));
+        $request = $request->withBody($stream);
 
         if (isset($contentType) && $contentType) {
             $request = $request->withHeader('content-type', $contentType);
@@ -307,6 +330,7 @@ class StreamableUpload
      * - resumable (UPLOAD_RESUMABLE_TYPE)
      * - media (UPLOAD_MEDIA_TYPE)
      * - multipart (UPLOAD_MULTIPART_TYPE)
+     *
      * @param $meta
      * @return string
      * @visible for testing


### PR DESCRIPTION
- Avoid exception `Call to undefined function GuzzleHttp\\Psr7\\stream_for()` on [Guzzle/Psr7^2.0.0](https://github.com/guzzle/psr7/releases/tag/2.0.0) released on 30 Jun, 
- support for old 'stream_for' function
- small doc fixes,
- fix examples and update readme

**Test:**
```batch
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.
Runtime:       PHP 8.0.5
Configuration: /google_flysystem/phpunit.xml.dist
......................                                            22 / 22 (100%)
Time: 02:04.269, Memory: 8.00 MB
OK ( 22 tests, 99 assertions)
```
Also please release for packagist