### PR TITLE
[v1] Improved Google library class loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,23 @@ composer require masbug/flysystem-google-drive-ext:"^1.0.0"
 
 ## Getting Google Keys
 
-#### Please follow [Google Docs](https://developers.google.com/drive/v3/web/enable-sdk) to obtain your `client ID, client secret & refresh token`. 
+#### Please follow [Google Docs](https://developers.google.com/drive/v3/web/enable-sdk) to obtain your `client ID, client secret & refresh token`.
+
 #### In addition you can also check these easy-to-follow tutorial by [@ivanvermeyen](https://github.com/ivanvermeyen/laravel-google-drive-demo)
--   [Getting your Client ID and Secret](https://github.com/ivanvermeyen/laravel-google-drive-demo/blob/master/README/1-getting-your-dlient-id-and-secret.md)
--   [Getting your Refresh Token](https://github.com/ivanvermeyen/laravel-google-drive-demo/blob/master/README/2-getting-your-refresh-token.md)
+
+- [Getting your Client ID and Secret](https://github.com/ivanvermeyen/laravel-google-drive-demo/blob/master/README/1-getting-your-dlient-id-and-secret.md)
+- [Getting your Refresh Token](https://github.com/ivanvermeyen/laravel-google-drive-demo/blob/master/README/2-getting-your-refresh-token.md)
 
 ## Usage
 
 ```php
-$client = new \Google_Client();
+$client = new \Google\Client();
 $client->setClientId([client_id]);
 $client->setClientSecret([client_secret]);
 $client->refreshToken([refresh_token]);
 $client->setApplicationName('My Google Drive App');
 
-$service = new \Google_Service_Drive($client);
+$service = new \Google\Service\Drive($client);
 
 // variant 1
 $adapter = new \Masbug\Flysystem\GoogleDriveAdapter($service, 'My_App_Root');
@@ -66,6 +68,7 @@ $adapter3 = new \Masbug\Flysystem\GoogleDriveAdapter(
 
 $fs = new \League\Flysystem\Filesystem($adapter, ['visibility' => AdapterInterface::VISIBILITY_PRIVATE]);
 ```
+
 ```php
 // List selected root folder contents
 $contents = $fs->listContents('', true /* is_recursive */);
@@ -75,6 +78,7 @@ $contents = $fs->listContents('MyFolder', true /* is_recursive */);
 ```
 
 ##### File upload
+
 ```php
 // Upload a file
 $local_filepath = '/home/user/downloads/file_to_upload.ext';
@@ -97,10 +101,11 @@ try {
     echo 'Source doesn\'t exist!';
 }
 
-// NOTE: Remote folders are automatically created. 
+// NOTE: Remote folders are automatically created.
 ```
 
 ##### File download
+
 ```php
 // Download a file
 $remote_filepath = 'MyFolder/file.ext';
@@ -125,14 +130,15 @@ try {
 ```
 
 ##### How to get TeamDrive list and IDs
+
 ```php
-$client = new \Google_Client();
+$client = new \Google\Client();
 $client->setClientId([client_id]);
 $client->setClientSecret([client_secret]);
 $client->refreshToken([refresh_token]);
 $client->setApplicationName('My Google Drive App');
 
-$service = new \Google_Service_Drive($client);
+$service = new \Google\Service\Drive($client);
 
 $drives = $service->teamdrives->listTeamdrives()->getTeamDrives();
 foreach ($drives as $drive) {
@@ -145,7 +151,9 @@ foreach ($drives as $drive) {
 ## Using with Laravel Framework
 
 ##### Update `.env` file with google keys
+
 Add the keys you created to your `.env` file and set `google` as your default cloud storage. You can copy the `.env.example` file and fill in the blanks.
+
 ```
 FILESYSTEM_CLOUD=google
 GOOGLE_DRIVE_CLIENT_ID=xxx.apps.googleusercontent.com
@@ -163,6 +171,7 @@ GOOGLE_DRIVE_FOLDER=
 ```
 
 ##### Add disks on `config/filesystems.php`
+
 ```php
 'disks' => [
     // ...
@@ -174,7 +183,7 @@ GOOGLE_DRIVE_FOLDER=
         'folder' => env('GOOGLE_DRIVE_FOLDER'), // without folder is root of drive or team drive
         //'teamDriveId' => env('GOOGLE_DRIVE_TEAM_DRIVE_ID'),
     ],
-    // you can use more accounts, only add more disks and configs on .env 
+    // you can use more accounts, only add more disks and configs on .env
     // also you can use the same account and point to a diferent folders for each disk
     /*'second_google' => [
         'driver' => 'google',
@@ -188,27 +197,39 @@ GOOGLE_DRIVE_FOLDER=
 ```
 
 ##### Add driver storage in a `ServiceProvider` on path `app/Providers/`
+
 Example:
+
 ```php
 namespace App\Providers;
 
-class AppServiceProvider extends \Illuminate\Support\ServiceProvider{ // can be a custom ServiceProvider
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\ServiceProvider;
+
+class AppServiceProvider extends ServiceProvider { // can be a custom ServiceProvider
     // ...
     public function boot(){
         // ...
-        try{
-            \Storage::extend('google', function($app, $config) {
-                $options = []; 
-                if(!empty($config['teamDriveId']??null)) $options['teamDriveId']=$config['teamDriveId']; 
-                $client = new \Google_Client();
+        try {
+            Storage::extend('google', function($app, $config) {
+                $options = [];
+
+                if(!empty($config['teamDriveId'] ?? null)) {
+                    $options['teamDriveId'] = $config['teamDriveId'];
+                }
+
+                $client = new \Google\Client();
                 $client->setClientId($config['clientId']);
                 $client->setClientSecret($config['clientSecret']);
                 $client->refreshToken($config['refreshToken']);
-                $service = new \Google_Service_Drive($client);
-                $adapter = new \Masbug\Flysystem\GoogleDriveAdapter($service,$config['folder']??'/', $options);
+                $service = new \Google\Service\Drive($client);
+                $adapter = new \Masbug\Flysystem\GoogleDriveAdapter($service, $config['folder'] ?? '/', $options);
+
                 return new \League\Flysystem\Filesystem($adapter);
             });
-        }catch(\Exception $e){  }
+        } catch(\Exception $e) {
+            // ...
+        }
         // ...
     }
     // ...
@@ -216,23 +237,27 @@ class AppServiceProvider extends \Illuminate\Support\ServiceProvider{ // can be 
 ```
 
 Now you can access the drives like so:
+
 ```php
 $googleDisk = Storage::disk('google');
 //$secondDisk = Storage::disk('second_google'); //others disks
 ```
 
 Keep in mind that there can only be one default cloud storage drive, defined by `FILESYSTEM_CLOUD` in your `.env` (or config) file. If you set it to `google`, that will be the cloud drive:
+
 ```php
 Storage::cloud(); // refers to Storage::disk('google')
 ```
 
 ## Limitations
+
 Using display paths as identifiers for folders and files requires them to be unique. Unfortunately Google Drive allows users to create files and folders with same (displayed) names. In such cases when unique path cannot be determined this adapter chooses the oldest (first) instance.
 In case the newer duplicate is a folder and user puts a unique file or folder inside the adapter will be able to reach it properly (because full path is unique).
 
-Concurrent use of same Google Drive might lead to unexpected problems due to heavy caching of file/folder identifiers and file objects.   
+Concurrent use of same Google Drive might lead to unexpected problems due to heavy caching of file/folder identifiers and file objects.
 
 ## Acknowledgements
+
 This adapter is based on wonderful [flysystem-google-drive](https://github.com/nao-pon/flysystem-google-drive) by Naoki Sawada.
 
 It also contains an adaptation of [Google_Http_MediaFileUpload](https://github.com/googleapis/google-api-php-client/blob/master/src/Http/MediaFileUpload.php) by Google. I've added support for resumable uploads directly from streams (avoiding copying data to memory).

--- a/src/StreamableUpload.php
+++ b/src/StreamableUpload.php
@@ -23,6 +23,9 @@ namespace Masbug\Flysystem;
 
 use Google_Client;
 use Google_Http_REST;
+use Google\Client;
+use Google\Exception;
+use Google\Http\REST;
 use GuzzleHttp\Psr7\LimitStream;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
@@ -61,7 +64,7 @@ class StreamableUpload
     /** @var int */
     private $progress;
 
-    /** @var Google_Client */
+    /** @var Google_Client|Client */
     private $client;
 
     /** @var \Psr\Http\Message\RequestInterface */
@@ -78,7 +81,7 @@ class StreamableUpload
     private $httpResultCode;
 
     /**
-     * @param  Google_Client  $client
+     * @param  Google_Client|Client  $client
      * @param  RequestInterface  $request
      * @param  string  $mimeType
      * @param  null|string|resource|StreamInterface  $data  Data you want to upload
@@ -87,7 +90,7 @@ class StreamableUpload
      *                               Only used if resumable=True.
      */
     public function __construct(
-        Google_Client $client,
+        $client,
         RequestInterface $request,
         $mimeType,
         $data,
@@ -238,7 +241,7 @@ class StreamableUpload
             return false;
         }
 
-        return Google_Http_REST::decodeHttpResponse($response, $this->request);
+        return REST::decodeHttpResponse($response, $this->request);
     }
 
     /**
@@ -397,7 +400,7 @@ class StreamableUpload
         $error = "Failed to start the resumable upload (HTTP {$message})";
         $this->client->getLogger()->error($error);
 
-        throw new \Google_Exception($error);
+        throw new Exception($error);
     }
 
     private function transformToUploadUrl()

--- a/tests/GoogleDriveAdapterTests.php
+++ b/tests/GoogleDriveAdapterTests.php
@@ -96,11 +96,11 @@ class GoogleDriveAdapterTests extends TestCase
             if (!empty($config['teamDriveId'] ?? null)) {
                 $options['teamDriveId'] = $config['teamDriveId'];
             }
-            $client = new \Google_Client();
+            $client = new \Google\Client();
             $client->setClientId($config['GOOGLE_DRIVE_CLIENT_ID']);
             $client->setClientSecret($config['GOOGLE_DRIVE_CLIENT_SECRET']);
             $client->refreshToken($config['GOOGLE_DRIVE_REFRESH_TOKEN']);
-            $service = new \Google_Service_Drive($client);
+            $service = new \Google\Service\Drive($client);
             return new GoogleDriveAdapter($service, 'tests/', $options);
         } catch (\Exception $e) {
             self::markTestSkipped($e->getMessage());


### PR DESCRIPTION
I updated all Google class load in the /src and /tests folder to reflect
the PSR-4 autoloading standard, and get rid of VSCode PHP intelephense.

And updated the README as well.

This commit is targeted to the branch 1.x with (hopefully) no breaking
changes.