### PR TITLE
Set root folder for appDataFolder spaces

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -241,12 +241,12 @@ class GoogleDriveAdapter extends AbstractAdapter
         } else {
             if (!$this->useDisplayPaths || $root === null) {
                 if ($root === null) {
-                    $root = 'root';
+                    $root = $this->spaces === 'appDataFolder' ? 'appDataFolder' : 'root';
                 }
                 $this->root = $root;
                 $this->setPathPrefix('');
             } else {
-                $this->root = 'root';
+                $this->root = $this->spaces === 'appDataFolder' ? 'appDataFolder' : 'root';
                 $this->setPathPrefix('');
 
                 // get real root id


### PR DESCRIPTION
This PR allows to use `appDataFolder` as spaces.

Actually this library uses `'root'` as the root folder. The name `'root'` is an alias to **My Drive**, but this alias only works on `'drive'` spaces.

If you want to use `appDataFolder` space it doesn't works because `'root'` is not a valid parent root folder.

Taking the Laravel Example, at the ServiceProvider, look at `$options`:

```php
namespace App\Providers;

use Illuminate\Support\Facades\Storage;
use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider { // can be a custom ServiceProvider
    // ...
    public function boot(){
        // ...
        try {
            \Storage::extend('google', function($app, $config) {
                $options = [
                    'spaces' => 'appDataFolder', // <==== This will fail without this PR
                ];

                if (!empty($config['teamDriveId'] ?? null)) {
                    $options['teamDriveId'] = $config['teamDriveId'];
                }

                $client = new \Google\Client();
                $client->setClientId($config['clientId']);
                $client->setClientSecret($config['clientSecret']);
                $client->refreshToken($config['refreshToken']);
                
                $service = new \Google\Service\Drive($client);
                $adapter = new \Masbug\Flysystem\GoogleDriveAdapter($service, $config['folder'] ?? '/', $options);
                $driver = new \League\Flysystem\Filesystem($adapter);

                return new \Illuminate\Filesystem\FilesystemAdapter($driver, $adapter);
            });
        } catch(\Exception $e) {
            // your exception handling logic
        }
        // ...
    }
    // ...
}
```