### PR TITLE
Fix google deprecations, better support for shared drives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,4 @@
 /phpunit.xml.dist   export-ignore
 /docs               export-ignore
 /tests              export-ignore
+/google-drive-service-account.json.example export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ google-drive-service-account.json
 build
 vendor
 .phpunit.result.cache
+.php_cs.cache

--- a/google-drive-service-account.json.example
+++ b/google-drive-service-account.json.example
@@ -1,0 +1,6 @@
+{
+    "GOOGLE_DRIVE_CLIENT_ID":"xxxxxx.apps.googleusercontent.com",
+    "GOOGLE_DRIVE_CLIENT_SECRET":"xxxxxx",
+    "GOOGLE_DRIVE_REFRESH_TOKEN":"xxxxxx",
+    "GOOGLE_DRIVE_TEAM_DRIVE_ID":null
+}

--- a/tests/GoogleDriveAdapterTests.php
+++ b/tests/GoogleDriveAdapterTests.php
@@ -93,8 +93,8 @@ class GoogleDriveAdapterTests extends TestCase
                 self::markTestSkipped("No google service config found in {$file}.");
             }
             $options = ['usePermanentDelete' => true];
-            if (!empty($config['teamDriveId'] ?? null)) {
-                $options['teamDriveId'] = $config['teamDriveId'];
+            if (!empty($config['GOOGLE_DRIVE_TEAM_DRIVE_ID'] ?? null)) {
+                $options['teamDriveId'] = $config['GOOGLE_DRIVE_TEAM_DRIVE_ID'];
             }
             $client = new \Google\Client();
             $client->setClientId($config['GOOGLE_DRIVE_CLIENT_ID']);


### PR DESCRIPTION
Reference https://github.com/masbug/flysystem-google-drive-ext/issues/57#issuecomment-1078186012
> I see that the parameter includeTeamDriveItems is deprecated and should be replace by includeItemsFromAllDrives (see https://developers.google.com/drive/api/v3/reference/files/list)

I tested V1 against shared drive(team drive) 
```batch
PHPUnit 9.5.20 

Runtime:       PHP 8.1.2
Configuration: /google_flysystem/phpunit.xml.dist

......................                                            22 / 22 (100%)

Time: 02:13.095, Memory: 8.00 MB

OK ( 22 tests, 99 assertions)
```