### PR TITLE
Fix `Timeout/Allowed memory exhausted` when to many files on `read/write/overwrite/rename/delete`

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -496,6 +496,9 @@ class GoogleDriveAdapter extends AbstractAdapter
             if (isset($this->cacheHasDirs[$srcId])) {
                 $this->cacheHasDirs[$id] = $this->cacheHasDirs[$srcId];
             }
+            if ($this->useDisplayPaths) {
+                $this->cachedPaths[trim($newpathDir.'/'.$fileName, '/')] = $id;
+            }
 
             if ($this->getRawVisibility($srcId) === AdapterInterface::VISIBILITY_PUBLIC) {
                 $this->publish($id);
@@ -1432,6 +1435,9 @@ class GoogleDriveAdapter extends AbstractAdapter
             $this->cacheFileObjects[$obj->getId()] = $obj;
             $this->cacheObjects([$obj->getId() => $obj]);
             $result = $this->normaliseObject($obj, self::dirname($path));
+            if ($this->useDisplayPaths) {
+                $this->cachedPaths[$result['display_path']] = $obj->getId();
+            }
 
             if (($visibility = $config->get('visibility'))) {
                 if ($this->setVisibility($result['virtual_path'], $visibility, true)) {
@@ -1774,7 +1780,10 @@ class GoogleDriveAdapter extends AbstractAdapter
                 if (DEBUG_ME) {
                     echo 'New req: '.$id;
                 }
-                $items[] = $this->getItems($id, false, 0, $is_last ? '' : 'mimeType = "'.self::DIRMIME.'"');
+
+                $query = $is_last ? [] : ['mimeType = "'.self::DIRMIME.'"'];
+                $query[] = "name = '{$token}'";
+                $items[] = $this->getItems($id, false, 0, implode(' and ', $query));
                 if (DEBUG_ME) {
                     echo " ...done\n";
                 }


### PR DESCRIPTION
There is a problem with the caching, when a folder has for example 1k files, i get `Timeout exception` or `Allowed memory exhausted` and the action is aborted, this is because it always tries to cache all the files on memory, but this is not necessary if you want `write/overwrite/read/rename/delete` only a single file

With this change the request must be faster because filter the files with the especific path on the query (`name = '{$token}'`), and less memory usage without loading unnecesary files

I don't know if this is a breaking change but i run the actual tests with and without `teamDrive`
```batch
PHPUnit 9.5.20

Runtime:       PHP 8.1.2
Configuration: /google_flysystem/phpunit.xml.dist

......................                                            22 / 22 (100%)

Time: 02:17.258, Memory: 8.00 MB

OK ( 22 tests, 99 assertions)
```
**Review the pros/cons/impact before merging, I don't want to break something with this change(like duplicating folders/files)**
