### PR TITLE
Fix `Properties can not be manipulated` when `useHasDir`

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -998,7 +998,9 @@ class GoogleDriveAdapter implements FilesystemAdapter
         $results = $batch->execute();
         foreach ($results as $key => $result) {
             if ($result instanceof FileList) {
-                $object[$paths[$key]]['hasdir'] = $this->cacheHasDirs[$paths[$key]] = (bool)$result->getFiles();
+                $array = $object[$paths[$key]]->jsonSerialize();
+                $array['extra_metadata']['hasdir'] = $this->cacheHasDirs[$paths[$key]] = (bool)$result->getFiles();
+                $object[$paths[$key]] = DirectoryAttributes::fromArray($array);
             }
         }
         $client->setUseBatch(false);


### PR DESCRIPTION
Closes #60
