### PR TITLE
Fix: Properly map virtual path when useDisplayPaths = false

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -1130,7 +1130,7 @@ class GoogleDriveAdapter extends AbstractAdapter
             $result['path'] = $result['display_path'];
         } else {
             $result['virtual_path'] = ($dirname ? ($dirname.'/') : '').$id;
-            $result['display_path'] = $this->toDisplayPath($result['virtual_path']);
+            $result['display_path'] = $result['virtual_path'];
 
             $result['path'] = $result['virtual_path'];
         }


### PR DESCRIPTION
This issue was fixed in the 2.x branch:
https://github.com/masbug/flysystem-google-drive-ext/commit/f9a69eefe01d0c8f78dd191c9c540740ade94735

This change should do it for the 1.x branch for those who are stuck in v1.