### PR TITLE
Update required google dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.3 | ^7.0",
         "league/flysystem": "^1.0",
-        "google/apiclient": "^2.2",
+        "google/apiclient": "^2.10",
         "guzzlehttp/psr7": "^1.7|^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This repository does rely on the new naming scheme (e.g. \Google\Service\Drive instead of \Google_Service_Drive). This is given starting at Google ApiClient 2.10.