### PR TITLE
Fix Countable error on php 8.1 in laravel 9

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -1031,7 +1031,7 @@ class GoogleDriveAdapter implements FilesystemAdapter
         $permissions = $file->getPermissions();
         $visibility = Visibility::PRIVATE;
 
-        if (! count($permissions)) {
+        if (is_null($permissions) || ! count($permissions)) {
             $permissions = $this->service->permissions->listPermissions($file->getId(), $this->applyDefaultParams([], 'permissions.list'));
             $file->setPermissions($permissions);
         }


### PR DESCRIPTION
Error message:
`count(): Argument #1 ($value) must be of type Countable|array, null given`