### PR TITLE
Add dirname to $result if DriveObject is a directory

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -1189,6 +1189,7 @@ class GoogleDriveAdapter implements FilesystemAdapter
             if ($this->useHasDir) {
                 $result['hasdir'] = isset($this->cacheHasDirs[$id]) ? $this->cacheHasDirs[$id] : false;
             }
+            $result['dirname'] = $path_parts['filename'];
             return new DirectoryAttributes(rtrim($result['display_path'], '/'), $visibility, strtotime($object->getModifiedTime()), $result);
         }
     }


### PR DESCRIPTION
If the object is a file, the name is also added to $result (see line 1184), but nof it it's a directory. It would be useful to see the directory name even if display paths are not used.