### PR TITLE
return infomration about uploaded file

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -439,6 +439,8 @@ class GoogleDriveAdapter implements FilesystemAdapter
         if (!isset($result) || !$result) {
             throw UnableToWriteFile::atLocation($path, 'Not able to write the file');
         }
+        
+        return $result;
     }
 
     /**

--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -439,7 +439,7 @@ class GoogleDriveAdapter implements FilesystemAdapter
         if (!isset($result) || !$result) {
             throw UnableToWriteFile::atLocation($path, 'Not able to write the file');
         }
-        
+
         return $result;
     }
 


### PR DESCRIPTION
Why not just return the `$result` variable in `writeData` method hence we can get information about uploaded file and avoid making another request ? this is the info we will get:

```php
$result = Storage::disk('google')->getDriver()->writeStream('composer.json', fopen('composer.json', 'r'))

//before:
//null

//after:
```

If this pr got merged it return:

```
 -type: "file"
  -path: "composer.json"
  -fileSize: 3771
  -visibility: "private"
  -lastModified: 267588571
  -mimeType: "text/plain"
  -extraMetadata: array:5 [
    "id" => "1VJsCmcGbJlgLl5YRW-Uf"
    "virtual_path" => "//1VJsCjR_Sy8FGbJlgLl5YRW-Uf"
    "display_path" => "composer.json"
    "filename" => "composer"
    "extension" => "json"
  ]
}

```

Also see https://github.com/masbug/flysystem-google-drive-ext/issues/72