### PR TITLE
Handle $permissions = null

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -1031,7 +1031,7 @@ class GoogleDriveAdapter implements FilesystemAdapter
         $permissions = $file->getPermissions();
         $visibility = Visibility::PRIVATE;
 
-        if (! count($permissions)) {
+        if (empty($permissions)) {
             $permissions = $this->service->permissions->listPermissions($file->getId(), $this->applyDefaultParams([], 'permissions.list'));
             $file->setPermissions($permissions);
         }


### PR DESCRIPTION
All of a sudden `$file->getPermissions()` returns `null` for some files.
`count()` only handles iterables, but the same conditional can be achieved with `empty()` which also supports `null`.