### PR TITLE
Fix Request is missing required authentication credential

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -339,12 +339,14 @@ class GoogleDriveAdapter implements FilesystemAdapter
     {
         $client = $this->service->getClient();
         if ($client->isAccessTokenExpired()) {
+            $client->getCache()->clear();
             if ($client->isUsingApplicationDefaultCredentials()) {
                 $client->fetchAccessTokenWithAssertion();
             } else {
                 $refreshToken = $client->getRefreshToken();
                 if ($refreshToken) {
                     $client->fetchAccessTokenWithRefreshToken($refreshToken);
+                    $this->service = new Drive($client);
                 }
             }
         }

--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -345,6 +345,7 @@ class GoogleDriveAdapter implements FilesystemAdapter
                 $refreshToken = $client->getRefreshToken();
                 if ($refreshToken) {
                     $client->fetchAccessTokenWithRefreshToken($refreshToken);
+                    $this->service = new Drive($client);
                 }
             }
         }


### PR DESCRIPTION
Fix Request is missing required authentication credential. Expected OAuth 2 access token, login cookie or other valid authentication credential