### PR TITLE
Add support for shared folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ $adapter3 = new \Masbug\Flysystem\GoogleDriveAdapter(
     ]
 );
 
+// variant 4: connect to a folder shared with you
+$adapter4 = new \Masbug\Flysystem\GoogleDriveAdapter(
+    $service,
+    'My_App_Root',
+    [
+        'sharedFolderId' => '0GF9IioKDqJsRGk9PVA'
+    ]
+);
+
 $fs = new \League\Flysystem\Filesystem($adapter, new \League\Flysystem\Config([\League\Flysystem\Config::OPTION_VISIBILITY => \League\Flysystem\Visibility::PRIVATE]));
 ```
 
@@ -159,6 +168,7 @@ GOOGLE_DRIVE_CLIENT_SECRET=xxx
 GOOGLE_DRIVE_REFRESH_TOKEN=xxx
 GOOGLE_DRIVE_FOLDER=
 #GOOGLE_DRIVE_TEAM_DRIVE_ID=xxx
+#GOOGLE_DRIVE_SHARED_FOLDER_ID=xxx
 
 # you can use more accounts, only add more configs
 #SECOND_GOOGLE_DRIVE_CLIENT_ID=xxx.apps.googleusercontent.com
@@ -166,6 +176,7 @@ GOOGLE_DRIVE_FOLDER=
 #SECOND_GOOGLE_DRIVE_REFRESH_TOKEN=xxx
 #SECOND_GOOGLE_DRIVE_FOLDER=backups
 #SECOND_DRIVE_TEAM_DRIVE_ID=xxx
+#SECOND_DRIVE_SHARED_FOLDER_ID=xxx
 ```
 
 ##### Add disks on `config/filesystems.php`
@@ -180,6 +191,7 @@ GOOGLE_DRIVE_FOLDER=
         'refreshToken' => env('GOOGLE_DRIVE_REFRESH_TOKEN'),
         'folder' => env('GOOGLE_DRIVE_FOLDER'), // without folder is root of drive or team drive
         //'teamDriveId' => env('GOOGLE_DRIVE_TEAM_DRIVE_ID'),
+        //'sharedFolderId' => env('GOOGLE_DRIVE_SHARED_FOLDER_ID'),
     ],
     // you can use more accounts, only add more disks and configs on .env
     // also you can use the same account and point to a diferent folders for each disk
@@ -214,6 +226,10 @@ class AppServiceProvider extends ServiceProvider { // can be a custom ServicePro
 
                 if (!empty($config['teamDriveId'] ?? null)) {
                     $options['teamDriveId'] = $config['teamDriveId'];
+                }
+
+                if (!empty($config['sharedFolderId'] ?? null)) {
+                    $options['sharedFolderId'] = $config['sharedFolderId'];
                 }
 
                 $client = new \Google\Client();

--- a/google-drive-service-account.json.example
+++ b/google-drive-service-account.json.example
@@ -2,5 +2,6 @@
     "GOOGLE_DRIVE_CLIENT_ID":"xxxxxx.apps.googleusercontent.com",
     "GOOGLE_DRIVE_CLIENT_SECRET":"xxxxxx",
     "GOOGLE_DRIVE_REFRESH_TOKEN":"xxxxxx",
-    "GOOGLE_DRIVE_TEAM_DRIVE_ID":null
+    "GOOGLE_DRIVE_TEAM_DRIVE_ID":null,
+    "GOOGLE_DRIVE_SHARED_FOLDER_ID":null
 }

--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -285,6 +285,20 @@ class GoogleDriveAdapter implements FilesystemAdapter
                 $this->rootId = $this->root;
                 $this->clearCache();
             }
+        } else if(isset($this->options['sharedFolderId'])) {
+            $this->root = (!$this->useDisplayPaths && $root !== null)
+                ? $root
+                : $this->options['sharedFolderId'];
+
+            $this->setPathPrefix('');
+
+            if ($this->useDisplayPaths && $root !== null) {
+                    // get real root id
+                    $this->root = $this->toSingleVirtualPath($root, false, true, true, true);
+                    // reset cache
+                    $this->rootId = $this->root;
+                    $this->clearCache();
+            }
         } else {
             if (!$this->useDisplayPaths || $root === null) {
                 if ($root === null) {

--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -285,7 +285,7 @@ class GoogleDriveAdapter implements FilesystemAdapter
                 $this->rootId = $this->root;
                 $this->clearCache();
             }
-        } else if(isset($this->options['sharedFolderId'])) {
+        } else if (isset($this->options['sharedFolderId'])) {
             $this->root = (!$this->useDisplayPaths && $root !== null)
                 ? $root
                 : $this->options['sharedFolderId'];
@@ -293,11 +293,11 @@ class GoogleDriveAdapter implements FilesystemAdapter
             $this->setPathPrefix('');
 
             if ($this->useDisplayPaths && $root !== null) {
-                    // get real root id
-                    $this->root = $this->toSingleVirtualPath($root, false, true, true, true);
-                    // reset cache
-                    $this->rootId = $this->root;
-                    $this->clearCache();
+                // get real root id
+                $this->root = $this->toSingleVirtualPath($root, false, true, true, true);
+                // reset cache
+                $this->rootId = $this->root;
+                $this->clearCache();
             }
         } else {
             if (!$this->useDisplayPaths || $root === null) {

--- a/tests/GoogleDriveAdapterTests.php
+++ b/tests/GoogleDriveAdapterTests.php
@@ -49,6 +49,9 @@ class GoogleDriveAdapterTests extends FilesystemAdapterTestCase
             if (!empty($config['GOOGLE_DRIVE_TEAM_DRIVE_ID'] ?? null)) {
                 $options['teamDriveId'] = $config['GOOGLE_DRIVE_TEAM_DRIVE_ID'];
             }
+            if (!empty($config['GOOGLE_DRIVE_SHARED_FOLDER_ID'] ?? null)) {
+                $options['sharedFolderId'] = $config['GOOGLE_DRIVE_SHARED_FOLDER_ID'];
+            }
             $client = new \Google\Client();
             $client->setClientId($config['GOOGLE_DRIVE_CLIENT_ID']);
             $client->setClientSecret($config['GOOGLE_DRIVE_CLIENT_SECRET']);


### PR DESCRIPTION
Hello, I made this PR to add a support for shared folders, in case you want to use a folder that is shared with the Google account you use.

There is the problem I encountered:
Because by default the root folder is set to _root_ here:
`$root = $this->spaces === 'appDataFolder' ? 'appDataFolder' : 'root';`
The first time it tries to resolve the folders name it searches folders present in the parent _root_, but the shared folder is not present in it because the folder does not belong to the Google account.