### PR TITLE
Fix count(): Argument #1 ($value) must be of type Countable|array on PHP 8.3

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -1000,7 +1000,7 @@ class GoogleDriveAdapter extends AbstractAdapter
         $permissions = $file->getPermissions();
         $visibility = AdapterInterface::VISIBILITY_PRIVATE;
 
-        if (! count($permissions)) {
+        if (! count($permissions ?: [])) {
             $permissions = $this->service->permissions->listPermissions($file->getId(), $this->applyDefaultParams([], 'permissions.list'));
             $file->setPermissions($permissions);
         }


### PR DESCRIPTION
`count(): Argument #1 ($value) must be of type Countable|array, null given`