### PR TITLE
Request webViewLink when listing

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -54,7 +54,7 @@ class GoogleDriveAdapter implements FilesystemAdapter
      *
      * @var string
      */
-    const FETCHFIELDS_LIST = 'files(id,mimeType,createdTime,modifiedTime,name,parents,permissions,size,webContentLink,shortcutDetails),nextPageToken';
+    const FETCHFIELDS_LIST = 'files(id,mimeType,createdTime,modifiedTime,name,parents,permissions,size,webContentLink,webViewLink,shortcutDetails),nextPageToken';
 
     /**
      * Fetch fields setting for get
@@ -995,7 +995,7 @@ class GoogleDriveAdapter implements FilesystemAdapter
                 return 'https://drive.google.com/drive/folders/'.$obj->id.'?usp=sharing';
             }
         }
-        return false;
+        return '';
     }
 
     /**


### PR DESCRIPTION
I'm not quite sure how to reproduce it, but for a couple of files, we were seeing a fatal error being generated when using the package with Oneduo\NovaFileManager:

> Oneduo\NovaFileManager\Entities\Entity::url(): Return value must be of type string, bool returned

It turns out the getUrl() method does return false when webViewLink is null. To work around that this PR:

1. Adds webViewLink to the list of fields required for lists
2. Make sure the getUrl() returns a string, as stated in its PHPdoc block.



