### PR TITLE
Add doc for accessing a shared folder on a team drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ $adapter4 = new \Masbug\Flysystem\GoogleDriveAdapter(
     ]
 );
 
+// variant 5: connect to a folder shared with you, which is on a shared team drive
+$adapter5 = new \Masbug\Flysystem\GoogleDriveAdapter(
+    $service,
+    'My_App_Root',
+    [
+        'sharedFolderId' => '0GF9IioKDqJsRGk9PVA'
+    ]
+);
+$adapter5->enableTeamDriveSupport();
+
 $fs = new \League\Flysystem\Filesystem($adapter, new \League\Flysystem\Config([\League\Flysystem\Config::OPTION_VISIBILITY => \League\Flysystem\Visibility::PRIVATE]));
 ```
 


### PR DESCRIPTION
To access a shared folder which is on a separate team drive without knowing the team drive ID,
the `enableTeamDriveSupport()` needs to be called explicitly. 

Otherwise, the folder won't be found and an error will occur:

```
Not able to write the file
```