### PR TITLE
Add support to set cached paths

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -267,6 +267,7 @@ class GoogleDriveAdapter implements FilesystemAdapter
         $this->useDisplayPaths = $this->options['useDisplayPaths'];
         $this->showDisplayPaths = $this->options['showDisplayPaths'];
         $this->optParams = $this->cleanOptParameters($this->options['parameters']);
+        $this->cachedPaths = $this->options['cachedPaths'] ?? [];
 
         if ($root !== null) {
             $root = trim($root, '/');
@@ -330,6 +331,16 @@ class GoogleDriveAdapter implements FilesystemAdapter
     {
         $this->refreshToken();
         return $this->service;
+    }
+
+    /**
+     * Gets the cached paths
+     *
+     * @return array
+     */
+    public function getCachedPaths(): array
+    {
+        return $this->cachedPaths;
     }
 
     /**


### PR DESCRIPTION
Adds support to get and set cached paths from options.

This allows the possibility to cache the paths across requests, greatly decreasing the number of requests required when working in large directory drives.