### PR TITLE
Update google/apiclient version to ^2.19

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-mbstring": "*",
         "guzzlehttp/guzzle": "^6.3 | ^7.0",
         "league/flysystem": "^2.1.1|^3.0",
-        "google/apiclient": "^2.2",
+        "google/apiclient": "^2.19",
         "guzzlehttp/psr7": "^1.7|^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
The issue stems from the dependency `google/apiclient:^2.2`, which requires `firebase/php-jwt:~6.0`. A security advisory has been issued against this version of firebase/php-jwt. You can review the advisory here:
https://github.com/advisories/GHSA-2x45-7fc3-mxwq

During composer update, the following error is encountered:

```
google/apiclient[v2.15.0, ..., v2.16.1] require firebase/php-jwt ~6.0 
-> found firebase/php-jwt[v6.0.0, ..., v6.11.1] but these were not loaded, 
because they are affected by security advisories ("PKSA-y2cr-5h3j-g3ys"). 
Go to https://packagist.org/security-advisories/ to find advisory details. 
To ignore the advisories, add them to the audit "ignore" config. 
To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
```

It appears that Composer is blocking the installation due to the reported vulnerability in the required JWT package.
